### PR TITLE
Add extenders information to “failedPredicateMap” in findNodesThatFit

### DIFF
--- a/plugin/pkg/scheduler/generic_scheduler.go
+++ b/plugin/pkg/scheduler/generic_scheduler.go
@@ -169,6 +169,23 @@ func findNodesThatFit(pod *api.Pod, nodeNameToInfo map[string]*schedulercache.No
 			if err != nil {
 				return api.NodeList{}, FailedPredicateMap{}, err
 			}
+			//add the extender failed info to failedPredicateMap
+			for _, filteredNode := range filtered {
+				nodeIn := false
+				for _, exNode := range filteredList.Items {
+					if filteredNode.Name == exNode.Name {
+						nodeIn = true
+						break
+					}
+				}
+				if !nodeIn {
+					if re, ok := extender.(*HTTPExtender); ok {
+						failedPredicateMap[filteredNode.Name] = re.extenderURL + ", " + re.filterVerb
+					} else {
+						failedPredicateMap[filteredNode.Name] = "extender failed"
+					}
+				}
+			}
 			filtered = filteredList.Items
 			if len(filtered) == 0 {
 				break


### PR DESCRIPTION
When all the filtered nodes that passed "predicateFuncs" don’t pass the extenders filter, the failedPredicateMap hasn’t the extenders information, should add it, I think. So when the length of the “filteredNodes.Items” is 0, we can know the integral information. (The length of the “filteredNodes.Items” is 0, may be because the extenders filter failed.)
